### PR TITLE
Fix ducktyping of fable to work with fable 2.x.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
@@ -24,6 +25,7 @@ build/Release
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
+package-lock.json
 
 # Users Environment Variables
 .lock-wscript

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "orator-session",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Session state and authentication manager for Orator Restful web API server.",
   "main": "source/Orator-Session.js",
   "scripts": {
-    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -u tdd -R spec",
+    "coverage": "nyc npm run test --reporter=lcov",
     "test": "./node_modules/mocha/bin/_mocha -u tdd -R spec"
   },
   "repository": {
@@ -23,17 +23,15 @@
   "homepage": "https://github.com/jasonhillier/orator-session",
   "devDependencies": {
     "async": "0.9.0",
-    "chai": "2.0.0",
+    "chai": "4.2.0",
     "codeclimate-test-reporter": "0.0.4",
     "coveralls": "2.11.2",
-    "istanbul": "0.3.5",
-    "mocha": "2.1.0",
-    "supertest": "0.15.0",
-    "fable": "^0.1.6",
-    "orator": "^1.0.18"
-  },
-  "optionalDependencies": {
-    "nodegrind": "0.4.0"
+    "fable": "^2.0.0",
+    "mocha": "6.1.4",
+    "nyc": "^14.1.0",
+    "orator": "^1.0.18",
+    "sinon": "^10.0.0",
+    "supertest": "6.1.3"
   },
   "dependencies": {
     "fable-uuid": "^1.0.3",

--- a/source/Orator-Session.js
+++ b/source/Orator-Session.js
@@ -9,7 +9,7 @@ var OratorSession = function()
 	function createNew(pFable)
 	{
 		// If a valid fable object isn't passed in, return a constructor
-		if ((typeof(pFable) !== 'object') || (!pFable.hasOwnProperty('fable')))
+		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
 			return {new: createNew};
 
 		var _Settings = pFable.settings;
@@ -135,7 +135,7 @@ var OratorSession = function()
 								// Touch the session so we reset timeout.
 								libSessionStore.touch(getSessionID(pRequest), _Settings.SessionTimeout, function (pError) { /* TODO: Log errors on the touch. */ });
 								pRequest[_Settings.SessionCookieName] = JSON.parse(pData)
-								
+
 								return fNext();
 							}
 						}
@@ -362,7 +362,7 @@ var OratorSession = function()
 				});
 			// This duplicates the session data for the Meadow endpoints //TODO: change meadow to use _Settings.SessionCookieName
 			pRequest.SessionData = pRequest[_Settings.SessionCookieName];
-			
+
 			return fNext();
 		}
 
@@ -397,7 +397,7 @@ var OratorSession = function()
 
 			// This will fail if the username or password are equal to false.  Not exactly bad....
 			if (!pRequest.Credentials ||
-				!pRequest.Credentials.username || 
+				!pRequest.Credentials.username ||
 				!pRequest.Credentials.password)
 			{
 				_Log.info('Authentication failure', {RemoteIP: remoteIP, LoginID: pRequest.Credentials.username, RequestID:pRequest.RequestUUID,Action:'Authenticate Validation',Success:false});
@@ -540,7 +540,7 @@ var OratorSession = function()
 				_Log.warn('getServerHostDomain -- request object missing headers!');
 				return false;
 			}
-			
+
 			var tmpHostDomain = '';
 			if (pRequest.headers['origin']) //some reverse proxies will give us this header
 			{
@@ -660,7 +660,7 @@ var OratorSession = function()
 						if (pData)
 						{
 							var tmpSessionData = JSON.parse(pData);
-							
+
 							// This happen when user logout. SessionID still exists in the memcache but UserID = 0.
 							if (tmpSessionData.UserID == 0)
 								return fNext();
@@ -676,9 +676,9 @@ var OratorSession = function()
 			{
 				if (pError)
 					return fCallback(pError);
-					
+
 				return fCallback(pError, tmpActiveUsers);
-			});			
+			});
 		}
 
 		var sessionStore = function()

--- a/source/strategies/InMemory.js
+++ b/source/strategies/InMemory.js
@@ -14,7 +14,7 @@ var InMemoryStrategy = function()
 	function createNew(pFable)
 	{
 		// If a valid fable object isn't passed in, return a constructor
-		if ((typeof(pFable) !== 'object') || (!pFable.hasOwnProperty('fable')))
+		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
 			return {new: createNew};
 		var _Log = pFable.log;
 		var _Settings = pFable.settings;
@@ -70,7 +70,7 @@ var InMemoryStrategy = function()
 
 			if (!_MemorySessionMap[pIDSession])
 				return fCallback('Session ID not found!');
-			
+
 			if (_MemorySessionMap[pIDSession])
 			{
 				_MemorySessionMap[pIDSession].Timestamp = Date.now();

--- a/source/strategies/Memcached.js
+++ b/source/strategies/Memcached.js
@@ -11,7 +11,7 @@ var MemcachedStrategy = function()
 	function createNew(pFable)
 	{
 		// If a valid fable object isn't passed in, return a constructor
-		if ((typeof(pFable) !== 'object') || (!pFable.hasOwnProperty('fable')))
+		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
 			return {new: createNew};
 		var _Log = pFable.log;
 		var _Settings = pFable.settings;

--- a/test/Orator_session_inmemory_tests.js
+++ b/test/Orator_session_inmemory_tests.js
@@ -9,6 +9,7 @@
 const Chai = require('chai');
 const Expect = Chai.expect;
 const Assert = Chai.assert;
+const Sinon = require('sinon');
 const libSuperTest = require('supertest');
 
 let _MockSettings = (
@@ -77,6 +78,35 @@ suite
 					function()
 					{
 						_Orator = require('orator').new(_MockSettings);
+					}
+				);
+				test
+				(
+					'Orator-Session recognizes fable 2.x',
+					function()
+					{
+						// given
+						const fable2x = require('fable').new({});
+						const oratorSession = require('../source/Orator-Session.js').new(fable2x);
+						const webServer =
+						{
+							get: (route, endpointHandlerMethod) => { },
+							use: (route, endpointHandlerMethod) => { },
+						};
+						Sinon.spy(webServer, 'get');
+						Sinon.spy(webServer, 'use');
+
+						// then
+						Expect(fable2x.hasOwnProperty('fable')).to.equal(false);
+						Expect('fable' in fable2x).to.equal(true);
+						Expect(oratorSession).to.be.an('object').that.has.a.property('connectRoutes');
+
+						// when
+						oratorSession.connectRoutes(webServer);
+
+						// then
+						Expect(webServer.get.callCount).to.equal(3);
+						Expect(webServer.use.callCount).to.equal(4);
 					}
 				);
 				test

--- a/test/Orator_session_memcached_tests.js
+++ b/test/Orator_session_memcached_tests.js
@@ -6,32 +6,37 @@
 * @author      Jason Hillier <jason@paviasystems.com>
 */
 
-var Chai = require("chai");
-var Expect = Chai.expect;
-var Assert = Chai.assert;
+const Chai = require('chai');
+const Expect = Chai.expect;
+const Assert = Chai.assert;
+const libSuperTest = require('supertest');
 
 var _MockSettings = (
 {
 	Product: 'MockOratorAlternate',
 	ProductVersion: '0.0.0',
 	APIServerPort: 8999,
-	"SessionTimeout":60,
-	"SessionStrategy": "Memcached",
-	"MemcachedURL":"127.0.0.1:11211",
-	"DefaultUsername": "user",
-	"DefaultPassword": "test"
+	SessionTimeout: 60,
+	SessionStrategy: 'Memcached',
+	MemcachedURL: '127.0.0.1:11211',
+	DefaultUsername: 'user',
+	DefaultPassword: 'test',
 });
 
-var libSuperTest = require('supertest').agent('http://localhost:' + _MockSettings.APIServerPort + '/');
-var libSuperTest2 = require('supertest').agent('http://localhost:' + _MockSettings.APIServerPort + '/');
+function newAgent()
+{
+	return libSuperTest.agent(`http://localhost:${_MockSettings.APIServerPort}/`);
+}
 
 suite
 (
 	'OratorSession',
 	function()
 	{
-		var _Orator;
-		var _OratorSession;
+		let _Orator;
+		let _OratorSession;
+		const _SharedAgent = newAgent();
+
 
 		setup
 		(
@@ -109,7 +114,7 @@ suite
 
 								_OratorSession.authenticateUser(pRequest, _OratorSession.defaultAuthenticator, function(err, result)
 								{
-									if (result && 
+									if (result &&
 										result.LoggedIn)
 									{
 										pResponse.send('Success');
@@ -132,7 +137,7 @@ suite
 					'Send test request to create session',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 								.get('TEST')
 								.end(
 									function (pError, pResponse)
@@ -151,7 +156,7 @@ suite
 					'Send request to authenticate a user (bad login)',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 								.get('AUTH?username=' +
 									encodeURIComponent('bad') + '&password=' +
 									encodeURIComponent('wrong'))
@@ -170,7 +175,7 @@ suite
 					'Send request to authenticate a user',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 								.get('AUTH?username=' +
 									encodeURIComponent(_MockSettings.DefaultUsername) + '&password=' +
 									encodeURIComponent(_MockSettings.DefaultPassword))
@@ -189,7 +194,7 @@ suite
 					'Send request to verify authorized users session',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 								.get('TEST')
 								.end(
 									function (pError, pResponse)
@@ -210,7 +215,7 @@ suite
 					'Checkout a temp session token',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 							.get('1.0/CheckoutSessionToken')
 							.end(
 								function (pError, pResponse)
@@ -227,12 +232,14 @@ suite
 							);
 					}
 				);
+				let tokenAgent;
 				test
 				(
 					'Test session token',
 					function(fDone)
 					{
-						libSuperTest2
+						tokenAgent = newAgent();
+						tokenAgent
 							.get('1.0/CheckSession?SessionToken=' + tmpSessionToken)
 							.end(
 								function (pError, pResponse)
@@ -252,7 +259,7 @@ suite
 					'Test Deauthenticate',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 							.get('1.0/Deauthenticate')
 							.end(
 								function (pError, pResponse)
@@ -271,7 +278,7 @@ suite
 					'Ensure logged-out status is maintained',
 					function(fDone)
 					{
-						libSuperTest
+						_SharedAgent
 							.get('1.0/CheckSession')
 							.end(
 								function (pError, pResponse)
@@ -290,7 +297,7 @@ suite
 					'Ensure logged-in status of token user is maintained',
 					function(fDone)
 					{
-						libSuperTest2
+						tokenAgent
 							.get('1.0/CheckSession')
 							.end(
 								function (pError, pResponse)
@@ -309,7 +316,8 @@ suite
 					'Request a session that doesnt exist',
 					function(fDone)
 					{
-						libSuperTest2
+						const doesNotExistAgent = newAgent();
+						doesNotExistAgent
 							.get('1.0/CheckSession')
 							.set( 'Cookie', 'UserSession=DoesNotExist' )
 							.end(


### PR DESCRIPTION
This is blocking me from updating the config service to fable 2.x.
* I updated a few unit tests which were failing.
* I also went ahead and updated some dependencies to current versions.
* Changed to checking for `'fable' in fable` rather than `fable.hasOwnPropery('fable')` which fails since it is a getter in 2.x.
* I upgraded the dev dependency on fable to 2.x and verified it is able to load as expected via a new unit test.
* I bumped the npm version.